### PR TITLE
Update module.cpp

### DIFF
--- a/interpreter/module.cpp
+++ b/interpreter/module.cpp
@@ -44,7 +44,18 @@ bool ModuleLoader::isLoaded() const {
 
 std::vector<ModuleLoader::EntryFunction> ModuleLoader::findEntryFunctions() {
     std::vector<EntryFunction> entryFunctions;
-#ifdef __linux__
+    if (!m_handle) return entryFunctions;
+
+#ifdef __ANDROID__
+    // Android 专用实现
+    void* sym = dlsym(m_handle, "_entry");
+    if (sym) {
+        auto entryFunc = reinterpret_cast<void (*)(Interpreter&)>(sym);
+        entryFunctions.push_back([entryFunc](Interpreter& interpreter) {
+            entryFunc(interpreter);
+        });
+    }    
+#else __linux__
     if (!m_handle) {
         return entryFunctions;
     }


### PR DESCRIPTION
对于安卓平台，绕过不支持的RTLD_DI_LINKMAP。适用于安卓的终端模拟器，如Termux。