### PR TITLE
将编译后的可执行文件设置在Lamina/bin路径下

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ project(Lamina)
 
 set(CMAKE_CXX_STANDARD 20)
 set(LIBUV_LIBRARY uv_a)
+
+# 设置可执行文件输出路径
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 # 设置libuv子模块路径
 set(LIBUV_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/external/libuv)
 


### PR DESCRIPTION
原来cmakefiles文件没有对可执行文件进行设置，现将可执行文件的路径设置在/bin方便之后的使用和配置环境变量